### PR TITLE
Add ability to require notes with code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,23 @@
       "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
+        "@js-joda/core": "^5.6.1",
         "crypto-js": "^4.2.0",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
-        "sanitizer-polyfill": "github:mozilla/sanitizer-polyfill#a1d64d48dd4349ab851b73e6019922c564208ed9"
+        "sanitizer-polyfill": "github:mozilla/sanitizer-polyfill#a1d64d48dd4349ab851b73e6019922c564208ed9",
+        "toposort": "^2.0.2"
       },
       "devDependencies": {
         "@types/crypto-js": "^4.2.0",
         "@types/node": "^16.11.6",
+        "@types/toposort": "^2.0.7",
         "@typescript-eslint/eslint-plugin": "^5.2.0",
         "@typescript-eslint/parser": "^5.2.0",
         "builtin-modules": "^3.2.0",
         "esbuild": "0.13.12",
         "obsidian": "latest",
+        "obsidian-dataview": "^0.5.64",
         "tslib": "2.3.1",
         "typescript": "4.4.4"
       }
@@ -106,6 +110,35 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/@js-joda/core": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.6.1.tgz",
+      "integrity": "sha512-Xla/d7ZMMR6+zRd6lTio0wRZECfcfFJP7GGe9A9L4tDOlD5CX4YcZ4YZle9w58bBYzssojVapI84RraKWDQZRg=="
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.0.tgz",
+      "integrity": "sha512-Wmvlm4q6tRpwiy20TnB3yyLTZim38Tkc50dPY8biQRwqE+ati/wD84rm3N15hikvdT4uSg9phs9ubjvcLmkpKg==",
+      "dev": true
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.0.tgz",
+      "integrity": "sha512-WrS5Mw51sGrpqjlh3d4/fOwpEV2Hd3YOkp9DBt4k8XZQcoTHZFB7sx030A6OcahF4J1nDQAa3jXlTVVYH50IFA==",
+      "dev": true,
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.14.tgz",
+      "integrity": "sha512-z5mY4LStlA3yL7aHT/rqgG614cfcvklS+8oFRFBYrs4YaWLJyKKM4+nN6KopToX0o9Hj6zmH6M5kinOYuy06ug==",
+      "dev": true,
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -182,6 +215,12 @@
       "dependencies": {
         "@types/estree": "*"
       }
+    },
+    "node_modules/@types/toposort": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/toposort/-/toposort-2.0.7.tgz",
+      "integrity": "sha512-sQNk65vbC36+UixCkcky+dCr7MlflHcVILg1FVGqlUntsLFv9xd9ToWIVko/gTuin+cVe16t+2YubEFkhnSuPQ==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.25.0",
@@ -618,6 +657,12 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.8.tgz",
       "integrity": "sha512-eVhaWoVibIzqdGYjwsBWodIQIaXFSB+cKDf4cfxLMsK0xiud6SE+/WCVx/Xw/UwQsa4cS3T2eITcdtmTg2UKcw=="
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
+      "dev": true
     },
     "node_modules/esbuild": {
       "version": "0.13.12",
@@ -1292,6 +1337,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -1420,6 +1471,24 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "dev": true,
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "dev": true,
+      "dependencies": {
+        "lie": "3.1.1"
+      }
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -1448,6 +1517,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/merge2": {
@@ -1485,15 +1563,6 @@
         "node": "*"
       }
     },
-    "node_modules/moment": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -1517,6 +1586,151 @@
         "@codemirror/view": "^0.19.31",
         "@types/codemirror": "0.0.108",
         "moment": "2.29.2"
+      }
+    },
+    "node_modules/obsidian-calendar-ui": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/obsidian-calendar-ui/-/obsidian-calendar-ui-0.3.12.tgz",
+      "integrity": "sha512-hdoRqCPnukfRgCARgArXaqMQZ+Iai0eY7f0ZsFHHfywpv4gKg3Tx5p47UsLvRO5DD+4knlbrL7Gel57MkfcLTw==",
+      "dev": true,
+      "dependencies": {
+        "obsidian-daily-notes-interface": "0.8.4",
+        "svelte": "3.35.0",
+        "tslib": "2.1.0"
+      }
+    },
+    "node_modules/obsidian-calendar-ui/node_modules/tslib": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+      "dev": true
+    },
+    "node_modules/obsidian-daily-notes-interface": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/obsidian-daily-notes-interface/-/obsidian-daily-notes-interface-0.8.4.tgz",
+      "integrity": "sha512-REKQtAuIOKDbvNH/th1C1gWmJWCP5tRn9T/mfZGZt4Zncgko7McXK0aSKFtEInipvgbZJ2nScivvyLdiWluSMw==",
+      "dev": true,
+      "dependencies": {
+        "obsidian": "github:obsidianmd/obsidian-api#master",
+        "tslib": "2.1.0"
+      },
+      "bin": {
+        "obsidian-daily-notes-interface": "dist/main.js"
+      }
+    },
+    "node_modules/obsidian-daily-notes-interface/node_modules/@codemirror/state": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.0.tgz",
+      "integrity": "sha512-hm8XshYj5Fo30Bb922QX9hXB/bxOAVH+qaqHBzw5TKa72vOeslyGwd4X8M0c1dJ9JqxlaMceOQ8RsL9tC7gU0A==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/obsidian-daily-notes-interface/node_modules/@codemirror/view": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.23.0.tgz",
+      "integrity": "sha512-/51px9N4uW8NpuWkyUX+iam5+PM6io2fm+QmRnzwqBy5v/pwGg9T0kILFtYeum8hjuvENtgsGNKluOfqIICmeQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@codemirror/state": "^6.4.0",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/obsidian-daily-notes-interface/node_modules/@types/codemirror": {
+      "version": "5.60.8",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
+      "integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
+      "dev": true,
+      "dependencies": {
+        "@types/tern": "*"
+      }
+    },
+    "node_modules/obsidian-daily-notes-interface/node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/obsidian-daily-notes-interface/node_modules/obsidian": {
+      "version": "1.5.1",
+      "resolved": "git+ssh://git@github.com/obsidianmd/obsidian-api.git#bbb696aeb8bf5126bf2ecbf84fc8284fe133bc20",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/codemirror": "5.60.8",
+        "moment": "2.29.4"
+      },
+      "peerDependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
+    "node_modules/obsidian-daily-notes-interface/node_modules/tslib": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+      "dev": true
+    },
+    "node_modules/obsidian-dataview": {
+      "version": "0.5.64",
+      "resolved": "https://registry.npmjs.org/obsidian-dataview/-/obsidian-dataview-0.5.64.tgz",
+      "integrity": "sha512-byp1bpsdchG3JWngfGb6jqe53gz6L9ou8LcbiBdMGKg2T2Po2ZtJWRoyX69f3CY7/SPZnyumveRaZ72vCDnyRA==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/language": "git+https://github.com/lishid/cm-language.git",
+        "@codemirror/state": "^6.0.1",
+        "@codemirror/view": "^6.0.1",
+        "emoji-regex": "^10.0.0",
+        "localforage": "^1.10.0",
+        "luxon": "^3.2.0",
+        "obsidian-calendar-ui": "^0.3.12",
+        "papaparse": "^5.3.1",
+        "parsimmon": "^1.18.0",
+        "preact": "^10.6.5"
+      }
+    },
+    "node_modules/obsidian-dataview/node_modules/@codemirror/language": {
+      "version": "6.9.2",
+      "resolved": "git+ssh://git@github.com/lishid/cm-language.git#cc6a2cc30288db6be3f879ddf0e3ef64f14ed6ab",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.1.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/obsidian-dataview/node_modules/@codemirror/state": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.0.tgz",
+      "integrity": "sha512-hm8XshYj5Fo30Bb922QX9hXB/bxOAVH+qaqHBzw5TKa72vOeslyGwd4X8M0c1dJ9JqxlaMceOQ8RsL9tC7gU0A==",
+      "dev": true
+    },
+    "node_modules/obsidian-dataview/node_modules/@codemirror/view": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.23.0.tgz",
+      "integrity": "sha512-/51px9N4uW8NpuWkyUX+iam5+PM6io2fm+QmRnzwqBy5v/pwGg9T0kILFtYeum8hjuvENtgsGNKluOfqIICmeQ==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/state": "^6.4.0",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/obsidian/node_modules/moment": {
+      "version": "2.29.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
+      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/once": {
@@ -1547,6 +1761,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/papaparse": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
+      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw==",
+      "dev": true
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -1559,6 +1779,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parsimmon": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.18.1.tgz",
+      "integrity": "sha512-u7p959wLfGAhJpSDJVYXoyMCXWYwHia78HhRBWqk7AIbxdmlrfdp5wX0l3xv/iTSH5HvhN9K7o26hwwpgS5Nmw==",
+      "dev": true
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
@@ -1599,6 +1825,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.19.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.19.3.tgz",
+      "integrity": "sha512-nHHTeFVBTHRGxJXKkKu5hT8C/YWBkPso4/Gad6xuj5dbptt9iF9NZr9pHbPhBrnT2klheu7mHTxTZ/LjwJiEiQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/prelude-ls": {
@@ -1825,9 +2061,9 @@
       }
     },
     "node_modules/style-mod": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
-      "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.0.tgz",
+      "integrity": "sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA==",
       "dev": true
     },
     "node_modules/supports-color": {
@@ -1841,6 +2077,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.35.0.tgz",
+      "integrity": "sha512-gknlZkR2sXheu/X+B7dDImwANVvK1R0QGQLd8CNIfxxGPeXBmePnxfzb6fWwTQRsYQG7lYkZXvpXJvxvpsoB7g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/text-table": {
@@ -1861,6 +2106,11 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
     },
     "node_modules/tslib": {
       "version": "2.3.1",
@@ -2066,6 +2316,35 @@
       "dev": true,
       "peer": true
     },
+    "@js-joda/core": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.6.1.tgz",
+      "integrity": "sha512-Xla/d7ZMMR6+zRd6lTio0wRZECfcfFJP7GGe9A9L4tDOlD5CX4YcZ4YZle9w58bBYzssojVapI84RraKWDQZRg=="
+    },
+    "@lezer/common": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.0.tgz",
+      "integrity": "sha512-Wmvlm4q6tRpwiy20TnB3yyLTZim38Tkc50dPY8biQRwqE+ati/wD84rm3N15hikvdT4uSg9phs9ubjvcLmkpKg==",
+      "dev": true
+    },
+    "@lezer/highlight": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.0.tgz",
+      "integrity": "sha512-WrS5Mw51sGrpqjlh3d4/fOwpEV2Hd3YOkp9DBt4k8XZQcoTHZFB7sx030A6OcahF4J1nDQAa3jXlTVVYH50IFA==",
+      "dev": true,
+      "requires": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "@lezer/lr": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.14.tgz",
+      "integrity": "sha512-z5mY4LStlA3yL7aHT/rqgG614cfcvklS+8oFRFBYrs4YaWLJyKKM4+nN6KopToX0o9Hj6zmH6M5kinOYuy06ug==",
+      "dev": true,
+      "requires": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2133,6 +2412,12 @@
       "requires": {
         "@types/estree": "*"
       }
+    },
+    "@types/toposort": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/toposort/-/toposort-2.0.7.tgz",
+      "integrity": "sha512-sQNk65vbC36+UixCkcky+dCr7MlflHcVILg1FVGqlUntsLFv9xd9ToWIVko/gTuin+cVe16t+2YubEFkhnSuPQ==",
+      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.25.0",
@@ -2418,6 +2703,12 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.8.tgz",
       "integrity": "sha512-eVhaWoVibIzqdGYjwsBWodIQIaXFSB+cKDf4cfxLMsK0xiud6SE+/WCVx/Xw/UwQsa4cS3T2eITcdtmTg2UKcw=="
+    },
+    "emoji-regex": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
+      "dev": true
     },
     "esbuild": {
       "version": "0.13.12",
@@ -2894,6 +3185,12 @@
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -2998,6 +3295,24 @@
         "type-check": "~0.4.0"
       }
     },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "dev": true,
+      "requires": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "dev": true,
+      "requires": {
+        "lie": "3.1.1"
+      }
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3021,6 +3336,12 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "luxon": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+      "dev": true
     },
     "merge2": {
       "version": "1.4.1",
@@ -3048,12 +3369,6 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "moment": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
-      "dev": true
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -3077,6 +3392,144 @@
         "@codemirror/view": "^0.19.31",
         "@types/codemirror": "0.0.108",
         "moment": "2.29.2"
+      },
+      "dependencies": {
+        "moment": {
+          "version": "2.29.2",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
+          "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
+          "dev": true
+        }
+      }
+    },
+    "obsidian-calendar-ui": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/obsidian-calendar-ui/-/obsidian-calendar-ui-0.3.12.tgz",
+      "integrity": "sha512-hdoRqCPnukfRgCARgArXaqMQZ+Iai0eY7f0ZsFHHfywpv4gKg3Tx5p47UsLvRO5DD+4knlbrL7Gel57MkfcLTw==",
+      "dev": true,
+      "requires": {
+        "obsidian-daily-notes-interface": "0.8.4",
+        "svelte": "3.35.0",
+        "tslib": "2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
+        }
+      }
+    },
+    "obsidian-daily-notes-interface": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/obsidian-daily-notes-interface/-/obsidian-daily-notes-interface-0.8.4.tgz",
+      "integrity": "sha512-REKQtAuIOKDbvNH/th1C1gWmJWCP5tRn9T/mfZGZt4Zncgko7McXK0aSKFtEInipvgbZJ2nScivvyLdiWluSMw==",
+      "dev": true,
+      "requires": {
+        "obsidian": "github:obsidianmd/obsidian-api#master",
+        "tslib": "2.1.0"
+      },
+      "dependencies": {
+        "@codemirror/state": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.0.tgz",
+          "integrity": "sha512-hm8XshYj5Fo30Bb922QX9hXB/bxOAVH+qaqHBzw5TKa72vOeslyGwd4X8M0c1dJ9JqxlaMceOQ8RsL9tC7gU0A==",
+          "dev": true,
+          "peer": true
+        },
+        "@codemirror/view": {
+          "version": "6.23.0",
+          "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.23.0.tgz",
+          "integrity": "sha512-/51px9N4uW8NpuWkyUX+iam5+PM6io2fm+QmRnzwqBy5v/pwGg9T0kILFtYeum8hjuvENtgsGNKluOfqIICmeQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@codemirror/state": "^6.4.0",
+            "style-mod": "^4.1.0",
+            "w3c-keyname": "^2.2.4"
+          }
+        },
+        "@types/codemirror": {
+          "version": "5.60.8",
+          "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
+          "integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
+          "dev": true,
+          "requires": {
+            "@types/tern": "*"
+          }
+        },
+        "moment": {
+          "version": "2.29.4",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+          "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+          "dev": true
+        },
+        "obsidian": {
+          "version": "git+ssh://git@github.com/obsidianmd/obsidian-api.git#bbb696aeb8bf5126bf2ecbf84fc8284fe133bc20",
+          "dev": true,
+          "from": "obsidian@github:obsidianmd/obsidian-api#master",
+          "requires": {
+            "@types/codemirror": "5.60.8",
+            "moment": "2.29.4"
+          }
+        },
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
+        }
+      }
+    },
+    "obsidian-dataview": {
+      "version": "0.5.64",
+      "resolved": "https://registry.npmjs.org/obsidian-dataview/-/obsidian-dataview-0.5.64.tgz",
+      "integrity": "sha512-byp1bpsdchG3JWngfGb6jqe53gz6L9ou8LcbiBdMGKg2T2Po2ZtJWRoyX69f3CY7/SPZnyumveRaZ72vCDnyRA==",
+      "dev": true,
+      "requires": {
+        "@codemirror/language": "git+https://github.com/lishid/cm-language.git",
+        "@codemirror/state": "^6.0.1",
+        "@codemirror/view": "^6.0.1",
+        "emoji-regex": "^10.0.0",
+        "localforage": "^1.10.0",
+        "luxon": "^3.2.0",
+        "obsidian-calendar-ui": "^0.3.12",
+        "papaparse": "^5.3.1",
+        "parsimmon": "^1.18.0",
+        "preact": "^10.6.5"
+      },
+      "dependencies": {
+        "@codemirror/language": {
+          "version": "git+ssh://git@github.com/lishid/cm-language.git#cc6a2cc30288db6be3f879ddf0e3ef64f14ed6ab",
+          "dev": true,
+          "from": "@codemirror/language@git+https://github.com/lishid/cm-language.git",
+          "requires": {
+            "@codemirror/state": "^6.0.0",
+            "@codemirror/view": "^6.0.0",
+            "@lezer/common": "^1.1.0",
+            "@lezer/highlight": "^1.0.0",
+            "@lezer/lr": "^1.0.0",
+            "style-mod": "^4.0.0"
+          }
+        },
+        "@codemirror/state": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.0.tgz",
+          "integrity": "sha512-hm8XshYj5Fo30Bb922QX9hXB/bxOAVH+qaqHBzw5TKa72vOeslyGwd4X8M0c1dJ9JqxlaMceOQ8RsL9tC7gU0A==",
+          "dev": true
+        },
+        "@codemirror/view": {
+          "version": "6.23.0",
+          "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.23.0.tgz",
+          "integrity": "sha512-/51px9N4uW8NpuWkyUX+iam5+PM6io2fm+QmRnzwqBy5v/pwGg9T0kILFtYeum8hjuvENtgsGNKluOfqIICmeQ==",
+          "dev": true,
+          "requires": {
+            "@codemirror/state": "^6.4.0",
+            "style-mod": "^4.1.0",
+            "w3c-keyname": "^2.2.4"
+          }
+        }
       }
     },
     "once": {
@@ -3104,6 +3557,12 @@
         "word-wrap": "^1.2.3"
       }
     },
+    "papaparse": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
+      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw==",
+      "dev": true
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3113,6 +3572,12 @@
       "requires": {
         "callsites": "^3.0.0"
       }
+    },
+    "parsimmon": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.18.1.tgz",
+      "integrity": "sha512-u7p959wLfGAhJpSDJVYXoyMCXWYwHia78HhRBWqk7AIbxdmlrfdp5wX0l3xv/iTSH5HvhN9K7o26hwwpgS5Nmw==",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -3138,6 +3603,12 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
+    "preact": {
+      "version": "10.19.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.19.3.tgz",
+      "integrity": "sha512-nHHTeFVBTHRGxJXKkKu5hT8C/YWBkPso4/Gad6xuj5dbptt9iF9NZr9pHbPhBrnT2klheu7mHTxTZ/LjwJiEiQ==",
       "dev": true
     },
     "prelude-ls": {
@@ -3280,9 +3751,9 @@
       "peer": true
     },
     "style-mod": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
-      "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.0.tgz",
+      "integrity": "sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA==",
       "dev": true
     },
     "supports-color": {
@@ -3294,6 +3765,12 @@
       "requires": {
         "has-flag": "^4.0.0"
       }
+    },
+    "svelte": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.35.0.tgz",
+      "integrity": "sha512-gknlZkR2sXheu/X+B7dDImwANVvK1R0QGQLd8CNIfxxGPeXBmePnxfzb6fWwTQRsYQG7lYkZXvpXJvxvpsoB7g==",
+      "dev": true
     },
     "text-table": {
       "version": "0.2.0",
@@ -3310,6 +3787,11 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
     },
     "tslib": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -11,20 +11,24 @@
   "author": "Victor Bjelkholm",
   "license": "MIT",
   "devDependencies": {
+    "@types/crypto-js": "^4.2.0",
     "@types/node": "^16.11.6",
+    "@types/toposort": "^2.0.7",
     "@typescript-eslint/eslint-plugin": "^5.2.0",
     "@typescript-eslint/parser": "^5.2.0",
-    "@types/crypto-js": "^4.2.0",
     "builtin-modules": "^3.2.0",
     "esbuild": "0.13.12",
     "obsidian": "latest",
+    "obsidian-dataview": "^0.5.64",
     "tslib": "2.3.1",
     "typescript": "4.4.4"
   },
   "dependencies": {
+    "@js-joda/core": "^5.6.1",
+    "crypto-js": "^4.2.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "sanitizer-polyfill": "github:mozilla/sanitizer-polyfill#a1d64d48dd4349ab851b73e6019922c564208ed9",
-    "crypto-js": "^4.2.0"
+    "toposort": "^2.0.2"
   }
 }

--- a/sci-js/deps.edn
+++ b/sci-js/deps.edn
@@ -1,6 +1,9 @@
 {:paths ["src/"]
  :deps {reagent/reagent {:mvn/version "1.1.0"}
-        borkdude/sci {:mvn/version "0.2.6"}}
+        borkdude/sci {:mvn/version "0.2.6"}
+        ;org.babashka/sci {:mvn/version "0.8.41"}
+        funcool/promesa {:mvn/version "8.0.450"}
+        com.widdindustries/cljc.java-time {:mvn/version "0.1.21"}}
  :aliases
  {:shadow-cljs
   {:extra-deps {thheller/shadow-cljs {:mvn/version "2.19.3"}}

--- a/sci-js/package-lock.json
+++ b/sci-js/package-lock.json
@@ -8,10 +8,18 @@
       "name": "sci-js-api",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@js-joda/core": "3.2.0"
+      },
       "devDependencies": {
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
       }
+    },
+    "node_modules/@js-joda/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -79,6 +87,11 @@
     }
   },
   "dependencies": {
+    "@js-joda/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/sci-js/package.json
+++ b/sci-js/package.json
@@ -11,5 +11,8 @@
   "devDependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
+  },
+  "dependencies": {
+    "@js-joda/core": "3.2.0"
   }
 }

--- a/sci-js/src/sci/api.cljs
+++ b/sci-js/src/sci/api.cljs
@@ -2,9 +2,14 @@
   (:require
     [clojure.pprint :refer [pprint]]
     [sci.core :as sci]
+    [sci.impl.vars]
     [reagent.core :as r]
     [reagent.dom :as rdom]
-    [cljs.repl :as repl]))
+    [cljs.repl :as repl]
+    [cljs.core :refer [clj->js]]
+    [promesa.core]
+    [cljc.java-time.local-date :as ld]
+    [cljc.java-time.format.date-time-formatter :as dtf]))
     ;; [clojure.repl :as repl]))
 
 ;; TODO This is not working correctly...
@@ -13,39 +18,69 @@
     (with-out-str
       (repl/doc x))))
 
-(defn ^:export init [js-global]
+(defn ^:export init [js-global o-bindings]
   (sci/init {:bindings {'hello "this is working"
                         'ratom r/atom
                         'doc doc}
-             :classes {'js js-global
-                       :allow :all}}))
+              :classes {'js js-global
+                        :allow :all}
+              :namespaces {'dtf {'of-pattern dtf/of-pattern}
+                           'ld {'format ld/format
+                                'parse ld/parse
+                                'plus-days ld/plus-days
+                                'minus-days ld/minus-days}
+                          'o (update-keys (js->clj o-bindings) symbol)
+                          'p {'all promesa.core/all
+                              'resolved promesa.core/resolved
+                              'rejected promesa.core/rejected
+                              'then (fn [p f] (promesa.core/then p (sci.impl.vars/binding-conveyor-fn f)))}
+                          'vars {'binding-conveyor-fn sci.impl.vars/binding-conveyor-fn}}}))
 
 (defn ^:export renderReagent [app container]
   (rdom/render app container))
 
 (defn ^:export ppStr [t]
-  (with-out-str (pprint t)))
+  (try
+    (with-out-str (pprint t))
+    (catch js/Error e t)))
 
-(defn ^:export evalString [ctx source {:keys [onRenderHTML
-                                              onRenderText
-                                              onRenderCode
-                                              onRenderReagent
-                                              onSetInterval]
-                                       :as opts}]
-  (sci/eval-string*
-    (assoc
-      ctx
-      :bindings
-      (assoc (:bindings ctx)
-             '*renderHTML (.-onRenderHTML ^js/Object opts)
-             '*renderText (.-onRenderText ^js/Object opts)
-             '*renderCode (.-onRenderCode ^js/Object opts)
-             '*renderReagent (fn [app container-el]
-                               (.onRenderReagent
-                                 opts
-                                 app))
-             'setInterval (.-onSetInterval ^js/Object opts)))
-    source))
+(def *renderCode (sci/new-dynamic-var '*renderCode nil))
+(def *renderText (sci/new-dynamic-var '*renderText nil))
+(def *renderMarkdown (sci/new-dynamic-var '*renderMarkdown nil))
+(def *renderHTML (sci/new-dynamic-var '*renderHTML nil))
+(def *renderReagent (sci/new-dynamic-var '*renderReagent nil))
+(def setInterval (sci/new-dynamic-var 'setInterval nil))
+(def chart (sci/new-dynamic-var 'chart nil))
+(def sci-current (sci/new-dynamic-var 'current nil))
+
+(defn ^:export evalString 
+  [ctx 
+   source 
+   {:keys [onRenderHTML onRenderText onRenderCode onRenderReagent onSetInterval onChart] :as opts}
+   current-page]
+  (sci/binding [*renderCode (.-onRenderCode ^js/Object opts)
+                *renderText (.-onRenderText ^js/Object opts)
+                *renderMarkdown (.-onRenderMarkdown ^js/Object opts)
+                *renderHTML (.-onRenderHTML ^js/Object opts)
+                *renderReagent (fn [app container-el] (.onRenderReagent opts app))
+                setInterval (.-onSetInterval ^js/Object opts)
+                chart #(.onChart ^js/Object opts (clj->js %))
+                sci-current (fn [] current-page)]
+    (sci/eval-string*
+      (assoc
+        ctx
+        :bindings
+        (assoc (:bindings ctx)
+               '*renderHTML *renderHTML
+               '*renderText *renderText
+               '*renderMarkdown *renderMarkdown
+               '*renderCode *renderCode
+               '*renderReagent *renderReagent
+               'setInterval setInterval
+               'chart chart
+               'current sci-current
+               ))
+      source)))
 
 (comment
   (def ctx (init nil))

--- a/src/main.ts
+++ b/src/main.ts
@@ -77,6 +77,10 @@ export default class ObsidianClojure extends Plugin {
 
     this.evaluator.setDocumentEvaluatedListener((documentEvaluation) => {
       this.workspaceWrapper.rerender(documentEvaluation.path)
+      const dependents = this.evaluator.getDependents(documentEvaluation.path)
+      for (const dependent of dependents) {
+        this.evaluator.evaluate(dependent, true)
+      }
     })
 
     this.registerMarkdownPostProcessor((el, context) => {
@@ -90,7 +94,7 @@ export default class ObsidianClojure extends Plugin {
       // TODO Look into context.addChild and whether we could get a callback when the file is closed, for example
       //   It might be a good spot to kill intervals
 
-      this.evaluator.evaluate(context.sourcePath, (documentEvaluation, cached) => {
+      this.evaluator.evaluate(context.sourcePath, false, (documentEvaluation, cached) => {
         if (cached) {
           documentEvaluation.attach(el, context.getSectionInfo(el))
         } else {


### PR DESCRIPTION
Frontmatter:

```
---
require:
    - "[[Code/Graphs]]"
    - …
---
```

Any Clojure code contained in the required files will be evaluated prior to evaluating the code in the file that requires them.

- The code from dependencies is only evaluated if it has changed since the last evaluation. So for example, if A depends on B, and B defines a var, it will not be redefined each time A is evaluated, only if the _source code_ of B changes. An easy workaround is to provide functions rather than variables.
- And if someone—me—already started using vars in some places before realizing this would be a problem I also added a hotkey/command that reevaluates everything.
- Circular dependencies are not supported (not sure what would happen at the moment, probably some kind of error would be displayed).
- Otherwise a dependency graph is generated in order to evaluate everything in the right order, since dependencies can have their own dependencies, etc.

Also a bunch of other stuff is included because I got carried away without committing anything for a while.